### PR TITLE
Simplify and fix install command for manual git clone installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ It fixes at least this known issue: https://gitlab.gnome.org/GNOME/mutter/issues
 43  
 
 ## Installation
-1. git clone git://github.com/BjoernDaase/remove-alt-tab-delay
-2. mv -r remove-alt-tab-delay ~/.local/share/gnome-shell/extensions
-3. Log out and log back in
-4. Activate the extension in the GNOME Extensions app
+1. `git clone https://github.com/bdaase/remove-alt-tab-delay ~/.local/share/gnome-shell/extensions/remove-alt-tab-delay@daase.net`
+2. Log out and log back in
+3. Activate the extension in the GNOME Extensions app


### PR DESCRIPTION
Three changes:

- Fixed the repository URL on git clone command to match your new username.

- We can specify a target folder directly on the git clone command `git clone (url) (dest)` so no need for the `mv` step.

- I had to add `@daase.net` to the extension folder name under `~/.local/share/gnome-shell/extensions/` for it to show under the GNOME Extensions app, discovered this by looking at `/usr/share/gnome-shell/extensions/` and noticing every extension's `uuid` on `metadata.json` must match the folder name, so simply adding the missing suffix fixes manual installation for the `remove-alt-tab-delay`, at least on GNOME 42.

Thanks!